### PR TITLE
[docs] add readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,101 @@
-# React + TypeScript + Vite
+# TMDB Home Assessment
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+## 專案簡介
 
-Currently, two official plugins are available:
+本專案為電影資訊瀏覽與收藏平台，串接 TMDB API，提供「最新電影清單」、「電影詳情（含演員、預告片、導演、評論）」與「待看清單」等功能，支援無限滾動、搜尋、收藏、評論瀏覽。
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+---
 
-## Expanding the ESLint configuration
+## 主要功能
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+- **最新電影清單**：支援無限滾動載入，並使用 lazy load 顯示電影卡片、評分、上映日、簡介。
+- **電影搜尋**：可依關鍵字搜尋電影。
+- **電影詳情頁**：
+  - 基本資訊、劇情簡介、評分、類型、製作公司、外部連結
+  - **演員陣容**（含頭像、角色名）
+  - **預告片**（YouTube 影片嵌入）
+  - **導演與主要工作人員**（頭像、職稱）
+  - **評論**（作者、內容、評分、連結）
+- **待看清單**：可將電影加入/移除收藏，並於專屬頁面瀏覽。
+- **全站統一 Loading/Error 處理**：React Query + 共用元件。
+- **RWD 響應式設計**：支援桌機與手機瀏覽。
 
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+---
 
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
+## 技術棧
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+- **前端框架**：React 19 + Vite + TypeScript
+- **狀態管理**：Zustand
+- **資料請求/快取**：@tanstack/react-query
+- **UI 樣式**：Tailwind CSS
+- **圖示**：Heroicons
+- **API**：TMDB (The Movie Database)
+- **Lint/格式化**：ESLint、Prettier
+
+---
+
+## 專案結構
+
+```
+tmdb-home-accessment/
+├── public/                # 靜態資源
+├── src/
+│   ├── assets/            # 靜態圖片、SVG
+│   ├── components/
+│   │   ├── common/        # 共用元件
+│   │   │   ├── MovieCard.tsx
+│   │   │   ├── PersonCard.tsx
+│   │   │   ├── BackButton.tsx
+│   │   │   ├── ReactQueryHandler.tsx
+│   │   │   ├── SearchBar.tsx
+│   │   │   └── ReactQueryProvider.tsx
+│   │   └── Layout/        # 版型元件
+│   │       ├── Header.tsx
+│   │       └── Layout.tsx
+│   ├── hooks/             # 自訂 React hooks
+│   │   ├── useReactQueryFetch.ts
+│   │   ├── useInfiniteScroll.ts
+│   │   └── useAppear.ts
+│   ├── lib/
+│   │   └── api/           # API 設定與服務
+│   │       ├── apiConfig.ts
+│   │       └── apiService.ts
+│   ├── pages/             # 主要頁面
+│   │   ├── MovieListPage.tsx
+│   │   ├── MovieDetailPage.tsx
+│   │   └── WatchlistPage.tsx
+│   ├── stores/            # 狀態管理（Zustand）
+│   │   └── watchlistStore.ts
+│   ├── types/             # TypeScript 型別定義
+│   │   └── tmdb.ts
+│   ├── test/              # 測試設定
+│   ├── App.tsx            # 入口元件
+│   ├── main.tsx           # 入口檔案
+│   ├── index.css          # 全域樣式
+│   └── router/            # 路由設定
+├── package.json
+├── vite.config.ts
+├── tailwind.config.js
+├── README.md
+└── ...（其他設定檔）
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+---
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## 安裝與啟動
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+1. **安裝依賴**
+   ```bash
+   npm install
+   ```
+
+2. **本地開發**
+   ```bash
+   npm run dev
+   ```
+
+---
+
+## 其他說明
+
+- **API 來源**：[TMDB 官方文件](https://developers.themoviedb.org/3)


### PR DESCRIPTION
# [docs] 新增專案 README 說明文件

## 背景描述 (Why)

為提升專案可讀性與協作效率，補充完整的 README 文件，讓開發者、審查者能快速了解專案功能、技術棧、資料夾結構與啟動方式。

## 實作方法 (How)

- 依據實際專案內容，撰寫專屬 README，涵蓋功能說明、技術棧、資料夾分佈、安裝與啟動指引。


## 實際變更（做了什麼）

- [x] 新增/覆蓋 README.md，內容包含：
  - 專案簡介
  - 主要功能（含 lazy load、無限滾動、收藏、詳情頁等）
  - 技術棧
  - 專案資料夾結構
  - 安裝與本地啟動說明
  - API 來源連結

## 補充說明

- 若未來有新功能或結構調整，請同步更新 README 內容
