### PR TITLE
[chore] Update package.json to include homepage URL and set base path…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "https://linyuhsuan.github.io/tmdb-home-accessment",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from 'path';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  // base: '/tmdb-home-accessment/',
+  base: '/tmdb-home-accessment/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
# [chore] Update package.json to include homepage URL and set base path in vite.config.ts for deployment

## 背景描述 (Why)

為了能夠成功部署 React 應用程式到 GitHub Pages，需要正確配置部署相關的設定。GitHub Pages 部署需要特定的路徑配置，以確保靜態資源能夠正確載入。

## 實作方法 (How)

採用 GitHub Pages 標準部署配置方式：
- 在 `package.json` 中設定 `homepage` 欄位指向 GitHub Pages URL
- 在 `vite.config.ts` 中設定 `base` 路徑以匹配 GitHub Pages 的子路徑結構
- 使用 `gh-pages` 套件進行自動化部署

## 實際變更（做了什麼）

- [x] 在 `package.json` 新增 `homepage` 欄位設定為 `https://linyuhsuan.github.io/tmdb-home-accessment`
- [x] 在 `vite.config.ts` 中啟用 `base: '/tmdb-home-accessment/'` 設定
- [x] 確保部署腳本 `predeploy` 和 `deploy` 已正確配置

